### PR TITLE
Use jitpack to specify cbioportal dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,19 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.mskcc.cbio</groupId>
+      <groupId>com.github.inodb</groupId>
       <artifactId>cbioportal</artifactId>
-      <version>1.3.0-SNAPSHOT</version>
-      <type>war</type>
+      <version>v1.3.0-test-jitpack</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>
+
+  <repositories>
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
+  </repositories>
   
   <build>
     <plugins>
@@ -27,7 +33,7 @@
         <configuration>
           <overlays>
             <overlay>
-              <groupId>org.mskcc.cbio</groupId>
+              <groupId>com.github.inodb.cbioportal</groupId>
               <artifactId>cbioportal</artifactId>
             </overlay>
           </overlays>


### PR DESCRIPTION
Proof of concept to show how one can use jitpack. Jitpack basically builds whatever mvn project you have on github and serves it. This way you can also refer to branches/commits if so desired.

If you want to merge, this first needs to be enabled on parent cbioportal/cbioportal project (not my fork).
